### PR TITLE
Update header style to glossy and unify fonts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -8,9 +8,9 @@
   --background-color: #000000;
   --gradient-start: #000000;
   --gradient-end: #222222;
-  --font-primary: 'Orbitron', sans-serif;
-  --font-secondary: 'Rajdhani', sans-serif;
-  --font-body: 'Inter', sans-serif;
+  --font-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-secondary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   --success-color: #00ff88;
   --warning-color: #ffaa00;
   --error-color: #ff4444;
@@ -230,14 +230,26 @@ header {
   z-index: 1000;
   transition: all 0.3s ease;
   padding: 20px 0;
-  backdrop-filter: blur(20px);
-  background: rgba(0, 0, 0, 0.8);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(20, 20, 20, 0.6);
+  backdrop-filter: saturate(180%) blur(20px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+header::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.05) 50%, rgba(255, 255, 255, 0) 100%);
 }
 
 header.scrolled {
   padding: 10px 0;
-  background: rgba(0, 0, 0, 0.95);
+  background: rgba(20, 20, 20, 0.85);
+  backdrop-filter: saturate(180%) blur(20px);
   box-shadow: 0 5px 20px rgba(0, 0, 0, 0.5);
   border-bottom: 1px solid var(--accent-color);
 }

--- a/index.html
+++ b/index.html
@@ -27,12 +27,9 @@
     <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
     
     <!-- Preconnect to external domains -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link rel="preconnect" href="https://cdnjs.cloudflare.com">
-    
-    <!-- Google Fonts -->
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Orbitron:wght@400;500;600;700;800&family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+    <!-- System Fonts -->
     
     <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-iecdLmaskl7CVkqkXNQ/ZH/XLlvWZOJyj7Yy7tcenmpD1ypASozpmT/E0iPtmFIB46ZmdtAc9eNBvH0H/ZpiBw==" crossorigin="anonymous" referrerpolicy="no-referrer">


### PR DESCRIPTION
## Summary
- remove Google Fonts and rely on system fonts
- apply system fonts across the site
- update header with glossy style using backdrop blur and gradient

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856bb2cdc98832bad2d197e69b7d791