### PR TITLE
Remove theme toggle and enforce dark mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -58,47 +58,6 @@ body {
   transition: width 0.1s ease;
 }
 
-/* Theme Toggle */
-.theme-toggle {
-  position: fixed;
-  top: 50%;
-  right: 20px;
-  transform: translateY(-50%);
-  width: 50px;
-  height: 50px;
-  background: rgba(26, 26, 64, 0.8);
-  border: 1px solid var(--accent-color);
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  z-index: 1000;
-  transition: all 0.3s ease;
-  backdrop-filter: blur(10px);
-}
-
-.theme-toggle:hover {
-  background: var(--accent-color);
-  color: var(--primary-color);
-  transform: translateY(-50%) scale(1.1);
-}
-
-.theme-toggle i {
-  font-size: 1.2rem;
-  transition: transform 0.3s ease;
-}
-
-/* Light Theme Variables */
-body.light-theme {
-  --primary-color: #f8f9fa;
-  --secondary-color: #6c5ce7;
-  --accent-color: #0984e3;
-  --text-color: #2d3436;
-  --background-color: #ffffff;
-  --gradient-start: #f8f9fa;
-  --gradient-end: #e9ecef;
-}
 
 /* Glowing elements */
 .glow {
@@ -1251,11 +1210,6 @@ footer::before {
     text-align: center;
   }
   
-  .theme-toggle {
-    right: 15px;
-    width: 45px;
-    height: 45px;
-  }
   
   .services-grid {
     grid-template-columns: 1fr;
@@ -1506,7 +1460,6 @@ nav ul li a:focus {
 @media print {
   .preloader,
   .scroll-top,
-  .theme-toggle,
   .custom-cursor,
   .cursor-follower,
   #particles-js {

--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,6 @@
 function initDeepDimensions() {
     initPreloader();
     initScrollProgress();
-    initThemeToggle();
     initHeroAnimation();
     initAboutAnimation();
     initParticles();
@@ -61,51 +60,6 @@ function initScrollProgress() {
     });
 }
 
-// Theme Toggle
-function initThemeToggle() {
-    const themeToggle = document.createElement('div');
-    themeToggle.className = 'theme-toggle';
-    themeToggle.innerHTML = '<i class="fas fa-sun"></i>';
-    themeToggle.setAttribute('aria-label', 'Toggle theme');
-    themeToggle.setAttribute('role', 'button');
-    themeToggle.setAttribute('tabindex', '0');
-    document.body.appendChild(themeToggle);
-    
-    // Check for saved theme preference
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme) {
-        document.body.classList.add(savedTheme);
-        updateThemeIcon(savedTheme === 'light-theme');
-    }
-    
-    themeToggle.addEventListener('click', toggleTheme);
-    themeToggle.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            toggleTheme();
-        }
-    });
-    
-    function toggleTheme() {
-        const isLight = document.body.classList.contains('light-theme');
-        document.body.classList.toggle('light-theme');
-        
-        const newTheme = isLight ? 'dark-theme' : 'light-theme';
-        localStorage.setItem('theme', newTheme);
-        updateThemeIcon(!isLight);
-        
-        // Add transition effect
-        document.body.style.transition = 'all 0.3s ease';
-        setTimeout(() => {
-            document.body.style.transition = '';
-        }, 300);
-    }
-    
-    function updateThemeIcon(isLight) {
-        const icon = themeToggle.querySelector('i');
-        icon.className = isLight ? 'fas fa-moon' : 'fas fa-sun';
-    }
-}
 
 // Enhanced Three.js scene for hero section
 function initHeroAnimation() {


### PR DESCRIPTION
## Summary
- remove the dynamic theme toggle script
- delete related toggle styles and the light theme CSS
- keep only the default dark look

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856bd91f364832bb67834879b347642