### PR TITLE
Reduce preloader time

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1258,7 +1258,7 @@ footer::before {
   justify-content: center;
   align-items: center;
   z-index: 9999;
-  transition: opacity 0.8s ease, visibility 0.8s ease;
+  transition: opacity 0.3s ease, visibility 0.3s ease;
 }
 
 .preloader.fade-out {

--- a/js/main.js
+++ b/js/main.js
@@ -34,14 +34,14 @@ function initPreloader() {
     // Add loading progress
     let progress = 0;
     const progressInterval = setInterval(() => {
-        progress += Math.random() * 15;
+        progress += 10; // finish loading in ~1 second
         if (progress >= 100) {
             progress = 100;
             clearInterval(progressInterval);
             setTimeout(() => {
                 preloader.classList.add('fade-out');
                 document.body.classList.remove('loading');
-            }, 500);
+            }, 200); // shorter delay before fade-out
         }
     }, 100);
 }


### PR DESCRIPTION
## Summary
- speed up the preloader progress
- shorten fade-out transition

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856dce2f2b0832b843b01b13f67425b