### PR TITLE
Fix overlay issue for missing JS

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1266,6 +1266,21 @@ footer::before {
   visibility: hidden;
 }
 
+.preloader.auto-fade {
+  animation: preloaderAutoFade 5s forwards;
+}
+
+@keyframes preloaderAutoFade {
+  from {
+    opacity: 1;
+    visibility: visible;
+  }
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
 .loader {
   width: 120px;
   height: 120px;

--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 <body class="loading">
 
     <!-- Preloader -->
-    <div class="preloader">
+    <div class="preloader auto-fade">
         <div class="loader"></div>
     </div>
     


### PR DESCRIPTION
## Summary
- automatically hide the preloader after five seconds
- ensure the preloader fades out even if JavaScript fails

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856e053b328832b9fd0eb5fb04480db