### PR TITLE
Remove gradient background for uniform black

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,7 +7,7 @@
   --text-color: #ffffff;
   --background-color: #000000;
   --gradient-start: #000000;
-  --gradient-end: #222222;
+  --gradient-end: #000000;
   --font-primary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   --font-secondary: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
   --font-body: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
@@ -336,7 +336,7 @@ nav ul li a:hover::after {
   left: 0;
   width: 100%;
   height: 100%;
-  background: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
+  background: none;
   z-index: 1;
 }
 
@@ -581,7 +581,7 @@ nav ul li a:hover::after {
   right: -50%;
   width: 100%;
   height: 200%;
-  background: radial-gradient(circle, rgba(255, 255, 255, 0.1) 0%, transparent 70%);
+  background: none;
   animation: float 6s ease-in-out infinite;
 }
 
@@ -1253,7 +1253,7 @@ footer::before {
   left: 0;
   width: 100%;
   height: 100%;
-  background: linear-gradient(135deg, var(--background-color), var(--primary-color));
+  background: var(--background-color);
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
## Summary
- use pure black for gradient-end variable
- remove radial gradients from hero and about sections
- make preloader background solid black

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856e0d2ce14832b88413571bc9e736b