### PR TITLE
Fix AOS fallback

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -22,6 +22,12 @@
   box-sizing: border-box;
 }
 
+/* Ensure content remains visible if AOS fails to initialize */
+body.no-aos [data-aos] {
+  opacity: 1 !important;
+  transform: none !important;
+}
+
 html {
   scroll-behavior: smooth;
   overflow-x: hidden;

--- a/js/main.js
+++ b/js/main.js
@@ -734,6 +734,12 @@ function initAOS() {
             easing: 'ease-out-cubic',
             anchorPlacement: 'top-bottom'
         });
+    } else {
+        // Fallback: reveal elements if AOS library fails to load
+        document.body.classList.add('no-aos');
+        document.querySelectorAll('[data-aos]').forEach(el => {
+            el.classList.add('aos-animate');
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure content sections remain visible even if AOS scripts fail
- add JS fallback to mark page as `no-aos`

## Testing
- `npm test` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856e62d86f4832ba7b3e4e30bf48943