### PR TITLE
Fix Our Services underline and icon sizing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -155,9 +155,10 @@ h2 {
 h2::after {
   content: '';
   position: absolute;
-  bottom: -10px;
-  left: 0;
-  width: 50%;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 100%;
   height: 3px;
   background: linear-gradient(to right, var(--accent-color), transparent);
 }
@@ -1117,7 +1118,7 @@ footer::before {
 
 .footer-links a i {
   margin-right: 10px;
-  font-size: 0.8rem;
+  font-size: 0.6rem;
   transition: transform 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- center the underline for `h2` headings so it sits directly below the text
- reduce the bullet/chevron icon size in the footer links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856f4502098832baed4231634a04392