### PR TITLE
Refine gradient menu styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -329,7 +329,7 @@ nav ul li a:hover::after {
 
 /* Gradient menu style */
 nav.gradient-menu ul {
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 @media (min-width: 769px) {
@@ -342,16 +342,17 @@ nav.gradient-menu ul {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 60px;
-    height: 60px;
+    width: 48px;
+    height: 48px;
     padding: 0;
     border-radius: 50%;
     background: #ffffff;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
     overflow: hidden;
     transition: all 0.5s ease;
     color: #333333;
-    font-size: 1rem;
+    font-size: 0.9rem;
   }
 
   nav.gradient-menu ul li a i {
@@ -375,7 +376,7 @@ nav.gradient-menu ul {
     position: absolute;
     inset: 0;
     border-radius: 50%;
-    background: linear-gradient(45deg, #222222, #000000);
+    background: linear-gradient(45deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.05));
     opacity: 0;
     transition: opacity 0.5s ease;
   }
@@ -388,7 +389,7 @@ nav.gradient-menu ul {
     right: 0;
     height: 100%;
     border-radius: 50%;
-    background: linear-gradient(45deg, #222222, #000000);
+    background: linear-gradient(45deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.05));
     filter: blur(15px);
     opacity: 0;
     transition: opacity 0.5s ease;
@@ -396,8 +397,8 @@ nav.gradient-menu ul {
   }
 
   nav.gradient-menu ul li a:hover {
-    width: 180px;
-    box-shadow: none;
+    width: 150px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
     color: #ffffff;
   }
 


### PR DESCRIPTION
## Summary
- shrink the gradient menu button size
- add subtle border and lighter gradient effect
- refine hover state shadow for a cleaner look

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6856f5daf46c832ba519a6c65e8a89db